### PR TITLE
Fix mobile navigation overflow on landing page

### DIFF
--- a/src/app/[locale]/(dashboard)/credits/page.tsx
+++ b/src/app/[locale]/(dashboard)/credits/page.tsx
@@ -75,8 +75,8 @@ export default function CreditsPage() {
   return (
     <div className="max-w-4xl mx-auto space-y-6">
       <div>
-        <h1 className="text-3xl font-bold">{t('title')}</h1>
-        <p className="text-muted-foreground">
+        <h1 className="text-2xl sm:text-3xl font-bold">{t('title')}</h1>
+        <p className="text-muted-foreground text-sm sm:text-base">
           {t('subtitle')}
         </p>
       </div>
@@ -105,12 +105,12 @@ export default function CreditsPage() {
           </CardTitle>
         </CardHeader>
         <CardContent>
-          <div className="flex items-center justify-between">
+          <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
             <div>
-              <p className="text-5xl font-bold">{credits}</p>
-              <p className="text-muted-foreground">{t('balance.available')}</p>
+              <p className="text-4xl sm:text-5xl font-bold">{credits}</p>
+              <p className="text-muted-foreground text-sm sm:text-base">{t('balance.available')}</p>
             </div>
-            <div className="text-right">
+            <div className="sm:text-right">
               <div className="flex items-center gap-2 text-sm text-muted-foreground">
                 <Clock className="h-4 w-4" />
                 <span>{t('balance.resetIn', { days: daysUntilReset })}</span>
@@ -135,7 +135,7 @@ export default function CreditsPage() {
           </CardDescription>
         </CardHeader>
         <CardContent>
-          <div className="grid gap-4 md:grid-cols-3">
+          <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 md:grid-cols-3">
             {CREDIT_PACKAGES.map((pkg) => (
               <div
                 key={pkg.id}

--- a/src/app/[locale]/(dashboard)/cv/page.tsx
+++ b/src/app/[locale]/(dashboard)/cv/page.tsx
@@ -64,13 +64,13 @@ export default function CVListPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
         <div>
-          <h1 className="text-3xl font-bold">{t('title')}</h1>
-          <p className="text-muted-foreground">{t('subtitle')}</p>
+          <h1 className="text-2xl sm:text-3xl font-bold">{t('title')}</h1>
+          <p className="text-muted-foreground text-sm sm:text-base">{t('subtitle')}</p>
         </div>
-        <Link href="/cv/new">
-          <Button>
+        <Link href="/cv/new" className="self-start sm:self-auto">
+          <Button size="sm" className="sm:size-default">
             <Plus className="mr-2 h-4 w-4" />
             {tDashboard('newCv')}
           </Button>
@@ -106,17 +106,17 @@ export default function CVListPage() {
               {cvs.map((cv) => (
                 <div
                   key={cv.id}
-                  className="flex items-center justify-between p-4 rounded-lg border"
+                  className="flex flex-col sm:flex-row sm:items-center justify-between p-3 sm:p-4 rounded-lg border gap-3"
                 >
-                  <div className="flex items-center gap-4">
-                    <div className="h-12 w-12 rounded-lg bg-primary/10 flex items-center justify-center">
-                      <FileText className="h-6 w-6 text-primary" />
+                  <div className="flex items-center gap-3 sm:gap-4 min-w-0 flex-1">
+                    <div className="h-10 w-10 sm:h-12 sm:w-12 rounded-lg bg-primary/10 flex items-center justify-center flex-shrink-0">
+                      <FileText className="h-5 w-5 sm:h-6 sm:w-6 text-primary" />
                     </div>
                     <div className="min-w-0 flex-1">
-                      <p className="font-medium truncate">
+                      <p className="font-medium truncate text-sm sm:text-base">
                         {cv.linkedInData?.fullName || tDashboard('recentCvs.untitled')}
                       </p>
-                      <div className="flex items-center gap-2 text-sm text-muted-foreground">
+                      <div className="flex flex-wrap items-center gap-1 sm:gap-2 text-xs sm:text-sm text-muted-foreground">
                         <span className="truncate">
                           {cv.jobVacancy?.title || tDashboard('recentCvs.generalCv')}
                         </span>
@@ -140,12 +140,12 @@ export default function CVListPage() {
                     </div>
                   </div>
 
-                  <div className="flex items-center gap-3">
+                  <div className="flex items-center justify-between sm:justify-end gap-2 sm:gap-3 flex-shrink-0">
                     {getStatusBadge(cv.status)}
 
                     <DropdownMenu>
                       <DropdownMenuTrigger asChild>
-                        <Button variant="ghost" size="icon">
+                        <Button variant="ghost" size="icon" className="h-8 w-8">
                           <MoreVertical className="h-4 w-4" />
                         </Button>
                       </DropdownMenuTrigger>

--- a/src/app/[locale]/(dashboard)/dashboard/page.tsx
+++ b/src/app/[locale]/(dashboard)/dashboard/page.tsx
@@ -61,17 +61,17 @@ export default function DashboardPage() {
   return (
     <div className="space-y-6">
       {/* Welcome Header */}
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
         <div>
-          <h1 className="text-3xl font-bold">
+          <h1 className="text-2xl sm:text-3xl font-bold">
             {t('welcome', { name: userData?.displayName || 'there' })}
           </h1>
-          <p className="text-muted-foreground">
+          <p className="text-muted-foreground text-sm sm:text-base">
             {t('subtitle')}
           </p>
         </div>
-        <Link href="/cv/new">
-          <Button>
+        <Link href="/cv/new" className="self-start sm:self-auto">
+          <Button size="sm" className="sm:size-default">
             <Plus className="mr-2 h-4 w-4" />
             {t('newCv')}
           </Button>
@@ -79,7 +79,7 @@ export default function DashboardPage() {
       </div>
 
       {/* Stats Grid */}
-      <div className="grid gap-6 md:grid-cols-3">
+      <div className="grid gap-4 sm:gap-6 grid-cols-1 sm:grid-cols-2 md:grid-cols-3">
         <Card>
           <CardHeader className="pb-2">
             <CardTitle className="text-sm font-medium text-muted-foreground">

--- a/src/app/[locale]/(dashboard)/layout.tsx
+++ b/src/app/[locale]/(dashboard)/layout.tsx
@@ -2,7 +2,7 @@
 
 import { useEffect } from 'react';
 import { useRouter } from '@/i18n/navigation';
-import { Sidebar } from '@/components/dashboard/sidebar';
+import { Sidebar, MobileHeader } from '@/components/dashboard/sidebar';
 import { AuthProvider, useAuth } from '@/components/auth/auth-context';
 import { Footer } from '@/components/footer';
 import { Loader2 } from 'lucide-react';
@@ -30,12 +30,15 @@ function DashboardContent({ children }: { children: React.ReactNode }) {
   }
 
   return (
-    <div className="min-h-screen flex">
+    <div className="min-h-screen flex flex-col md:flex-row">
       <Sidebar />
-      <main className="flex-1 overflow-auto flex flex-col">
-        <div className="container mx-auto p-6 flex-1">{children}</div>
-        <Footer minimal />
-      </main>
+      <div className="flex-1 flex flex-col min-h-screen md:min-h-0">
+        <MobileHeader />
+        <main className="flex-1 overflow-auto flex flex-col">
+          <div className="container mx-auto p-4 md:p-6 flex-1">{children}</div>
+          <Footer minimal />
+        </main>
+      </div>
     </div>
   );
 }

--- a/src/app/[locale]/(dashboard)/profiles/page.tsx
+++ b/src/app/[locale]/(dashboard)/profiles/page.tsx
@@ -62,14 +62,14 @@ export default function ProfilesPage() {
 
   return (
     <div className="space-y-6">
-      <div className="flex items-center justify-between">
+      <div className="flex flex-col sm:flex-row sm:items-center justify-between gap-4">
         <div>
-          <h1 className="text-2xl font-bold tracking-tight">{t('title')}</h1>
-          <p className="text-muted-foreground">
+          <h1 className="text-xl sm:text-2xl font-bold tracking-tight">{t('title')}</h1>
+          <p className="text-muted-foreground text-sm sm:text-base">
             {t('subtitle')}
           </p>
         </div>
-        <Button onClick={() => router.push('/cv/new')}>
+        <Button onClick={() => router.push('/cv/new')} size="sm" className="self-start sm:self-auto sm:size-default">
           <Plus className="h-4 w-4 mr-2" />
           {t('newProfile')}
         </Button>
@@ -97,7 +97,7 @@ export default function ProfilesPage() {
           </CardContent>
         </Card>
       ) : (
-        <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+        <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 lg:grid-cols-3">
           {profiles.map((profile) => (
             <ProfileCard
               key={profile.id}

--- a/src/app/[locale]/page.tsx
+++ b/src/app/[locale]/page.tsx
@@ -85,20 +85,23 @@ export default async function LandingPage({ params }: Props) {
       <div className="min-h-screen flex flex-col">
         {/* Header */}
         <header className="border-b sticky top-0 bg-background/95 backdrop-blur supports-[backdrop-filter]:bg-background/60 z-50">
-          <div className="container mx-auto px-4 h-16 flex items-center justify-between">
-            <Link href="/">
+          <div className="container mx-auto px-4 h-16 flex items-center justify-between max-w-full overflow-x-hidden">
+            <Link href="/" className="flex-shrink-0">
               <Logo size="sm" />
             </Link>
-            <div className="flex items-center gap-2">
+            <nav className="flex items-center gap-1 sm:gap-2">
               <ThemeSwitcher />
               <LanguageSwitcher />
               <Link href="/login">
-                <Button variant="ghost">{locale === 'nl' ? 'Inloggen' : 'Sign In'}</Button>
+                <Button variant="ghost" size="sm">
+                  <User className="h-4 w-4 sm:hidden" />
+                  <span className="hidden sm:inline">{locale === 'nl' ? 'Inloggen' : 'Sign In'}</span>
+                </Button>
               </Link>
               <Link href="/register">
-                <Button>{t('ctaStart')}</Button>
+                <Button size="sm" className="text-xs sm:text-sm whitespace-nowrap">{t('ctaStart')}</Button>
               </Link>
-            </div>
+            </nav>
           </div>
         </header>
 

--- a/src/components/cv/cv-content-editor.tsx
+++ b/src/components/cv/cv-content-editor.tsx
@@ -311,7 +311,7 @@ export function CVContentEditor({
             {/* Contact Info */}
             <div className="pt-2 border-t space-y-2">
               <span className="text-xs text-muted-foreground font-medium">Contactgegevens</span>
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-2">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
                 <div className="flex items-center gap-2">
                   <Mail className="h-4 w-4 text-muted-foreground flex-shrink-0" />
                   <EditableField

--- a/src/components/cv/cv-preview.tsx
+++ b/src/components/cv/cv-preview.tsx
@@ -288,7 +288,7 @@ export function CVPreview({
                 </div>
               </AccordionTrigger>
               <AccordionContent className="px-4 pb-4">
-                <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                   {/* Profile Info */}
                   <div className="space-y-2 p-3 border rounded-lg bg-background">
                     <h4 className="font-medium text-sm flex items-center gap-2 text-muted-foreground">
@@ -451,15 +451,19 @@ export function CVPreview({
           </Accordion>
 
           <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full">
-            <TabsList className="grid w-full grid-cols-4 mb-4">
-              <TabsTrigger value="preview">Preview</TabsTrigger>
-              <TabsTrigger value="edit" className="flex items-center gap-1">
+            <TabsList className="grid w-full grid-cols-2 sm:grid-cols-4 mb-4 h-auto">
+              <TabsTrigger value="preview" className="text-xs sm:text-sm">Preview</TabsTrigger>
+              <TabsTrigger value="edit" className="flex items-center gap-1 text-xs sm:text-sm">
                 <Pencil className="h-3 w-3" />
-                Bewerken
+                <span className="hidden sm:inline">Bewerken</span>
+                <span className="sm:hidden">Edit</span>
                 {hasEdits && <span className="ml-1 h-2 w-2 rounded-full bg-primary" />}
               </TabsTrigger>
-              <TabsTrigger value="style">Stijl Details</TabsTrigger>
-              <TabsTrigger value="html">HTML</TabsTrigger>
+              <TabsTrigger value="style" className="text-xs sm:text-sm">
+                <span className="hidden sm:inline">Stijl Details</span>
+                <span className="sm:hidden">Stijl</span>
+              </TabsTrigger>
+              <TabsTrigger value="html" className="text-xs sm:text-sm">HTML</TabsTrigger>
             </TabsList>
 
             <TabsContent value="preview" className="space-y-4">
@@ -521,7 +525,7 @@ export function CVPreview({
 
             <TabsContent value="style" className="space-y-4">
               {/* Style tokens display */}
-              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 {/* Theme & Colors */}
                 <div className="space-y-3 p-4 border rounded-lg">
                   <h3 className="font-semibold text-sm text-muted-foreground uppercase tracking-wide">

--- a/src/components/cv/job-input.tsx
+++ b/src/components/cv/job-input.tsx
@@ -593,7 +593,7 @@ Wat we vragen:
       </CardHeader>
       <CardContent>
         <form onSubmit={handleSubmit(handleEditSave)} className="space-y-4">
-          <div className="grid gap-4 md:grid-cols-2">
+          <div className="grid gap-4 grid-cols-1 sm:grid-cols-2">
             <div className="space-y-2">
               <Label htmlFor="title">Functietitel *</Label>
               <Input
@@ -616,7 +616,7 @@ Wat we vragen:
             </div>
           </div>
 
-          <div className="grid gap-4 md:grid-cols-3">
+          <div className="grid gap-4 grid-cols-1 sm:grid-cols-2 md:grid-cols-3">
             <div className="space-y-2">
               <Label htmlFor="location">Locatie</Label>
               <Input
@@ -731,7 +731,7 @@ Wat we vragen:
             </div>
 
             {/* Salary Range */}
-            <div className="grid gap-4 md:grid-cols-4">
+            <div className="grid gap-4 grid-cols-2 sm:grid-cols-3 md:grid-cols-4">
               <div className="space-y-2">
                 <Label htmlFor="salaryMin" className="text-sm">Minimum Salaris</Label>
                 <Input
@@ -826,7 +826,7 @@ Wat we vragen:
             </div>
 
             {/* Bonus & Notes */}
-            <div className="grid gap-4 md:grid-cols-2">
+            <div className="grid gap-4 grid-cols-1 sm:grid-cols-2">
               <div className="space-y-2">
                 <Label htmlFor="bonusInfo" className="text-sm">Bonus (optioneel)</Label>
                 <Input

--- a/src/components/cv/linkedin-input.tsx
+++ b/src/components/cv/linkedin-input.tsx
@@ -374,7 +374,7 @@ export function LinkedInInput({ onParsed, onTokenUsage, initialData, modelInfo, 
           {/* Basic Fields */}
           <div className="space-y-4">
             <h3 className="font-semibold text-sm text-muted-foreground uppercase tracking-wide">Basis Gegevens</h3>
-            <div className="grid gap-4 md:grid-cols-2">
+            <div className="grid gap-4 grid-cols-1 sm:grid-cols-2">
               <div className="space-y-2">
                 <Label htmlFor="edit-fullName">Naam</Label>
                 <Input
@@ -432,7 +432,7 @@ export function LinkedInInput({ onParsed, onTokenUsage, initialData, modelInfo, 
                     <Trash2 className="h-4 w-4 text-destructive" />
                   </Button>
                 </div>
-                <div className="grid gap-3 md:grid-cols-2">
+                <div className="grid gap-3 grid-cols-1 sm:grid-cols-2">
                   <div className="space-y-1">
                     <Label className="text-xs">Functie</Label>
                     <Input
@@ -515,7 +515,7 @@ export function LinkedInInput({ onParsed, onTokenUsage, initialData, modelInfo, 
                     <Trash2 className="h-4 w-4 text-destructive" />
                   </Button>
                 </div>
-                <div className="grid gap-3 md:grid-cols-2">
+                <div className="grid gap-3 grid-cols-1 sm:grid-cols-2">
                   <div className="space-y-1">
                     <Label className="text-xs">School / Universiteit</Label>
                     <Input
@@ -683,7 +683,7 @@ export function LinkedInInput({ onParsed, onTokenUsage, initialData, modelInfo, 
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          <div className="grid gap-4 md:grid-cols-2">
+          <div className="grid gap-4 grid-cols-1 sm:grid-cols-2">
             <div>
               <p className="text-sm font-medium text-muted-foreground">Name</p>
               <p className="text-lg font-semibold">{parsed.fullName}</p>

--- a/src/components/cv/profile-input.tsx
+++ b/src/components/cv/profile-input.tsx
@@ -884,7 +884,7 @@ export function ProfileInput({
           {/* Basic Fields */}
           <div className="space-y-4">
             <h3 className="font-semibold text-sm text-muted-foreground uppercase tracking-wide">Basis Gegevens</h3>
-            <div className="grid gap-4 md:grid-cols-2">
+            <div className="grid gap-4 grid-cols-1 sm:grid-cols-2">
               <div className="space-y-2">
                 <Label htmlFor="edit-fullName">Naam</Label>
                 <Input
@@ -942,7 +942,7 @@ export function ProfileInput({
                     <Trash2 className="h-4 w-4 text-destructive" />
                   </Button>
                 </div>
-                <div className="grid gap-3 md:grid-cols-2">
+                <div className="grid gap-3 grid-cols-1 sm:grid-cols-2">
                   <div className="space-y-1">
                     <Label className="text-xs">Functie</Label>
                     <Input
@@ -1025,7 +1025,7 @@ export function ProfileInput({
                     <Trash2 className="h-4 w-4 text-destructive" />
                   </Button>
                 </div>
-                <div className="grid gap-3 md:grid-cols-2">
+                <div className="grid gap-3 grid-cols-1 sm:grid-cols-2">
                   <div className="space-y-1">
                     <Label className="text-xs">School / Universiteit</Label>
                     <Input
@@ -1194,7 +1194,7 @@ export function ProfileInput({
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          <div className="grid gap-4 md:grid-cols-2">
+          <div className="grid gap-4 grid-cols-1 sm:grid-cols-2">
             <div>
               <p className="text-sm font-medium text-muted-foreground">Naam</p>
               <p className="text-lg font-semibold">{parsed.fullName}</p>
@@ -1259,7 +1259,7 @@ export function ProfileInput({
             <p className="text-xs text-muted-foreground mb-3">
               LinkedIn exporteert geen contactgegevens - vul deze hieronder in!
             </p>
-            <div className="grid gap-3 md:grid-cols-2">
+            <div className="grid gap-3 grid-cols-1 sm:grid-cols-2">
               <div className="space-y-1">
                 <Label htmlFor="email" className="text-xs text-muted-foreground">Email *</Label>
                 <Input

--- a/src/components/cv/style-picker.tsx
+++ b/src/components/cv/style-picker.tsx
@@ -84,7 +84,7 @@ export function StylePicker({ onSelect, initialTemplate, initialColorScheme }: S
         {/* Template Selection */}
         <div className="space-y-3">
           <Label>Template</Label>
-          <div className="grid gap-3 md:grid-cols-3">
+          <div className="grid gap-3 grid-cols-1 sm:grid-cols-2 md:grid-cols-3">
             {templates.map((template) => (
               <button
                 key={template.id}


### PR DESCRIPTION
- Add overflow-x-hidden and max-w-full to prevent horizontal overflow
- Reduce gap between nav items on mobile (gap-1 vs gap-2)
- Show user icon instead of text for login button on mobile
- Make CTA button smaller on mobile with responsive text size
- Add flex-shrink-0 to logo to prevent shrinking
- Add whitespace-nowrap to CTA button to prevent text wrapping